### PR TITLE
getTitle

### DIFF
--- a/getTitle.js
+++ b/getTitle.js
@@ -1,0 +1,22 @@
+const fetch = require('node-fetch');
+
+function getTitle(url){
+    let response = fetch(url)
+        .then(res => res.text())
+        .then(body => body.match(/<title>(?<title>.*)<\/title>/i).groups.title)
+
+    return response
+}
+
+///////////*  testing   see console  *////////////
+
+function checkA() {
+    setInterval(() => {
+        console.log(A)
+    },1000)
+}
+
+let A = getTitle('https://dolphin-emu.org/blog/2020/02/07/dolphin-progress-report-dec-2019-and-jan-2020/')
+
+checkA()
+


### PR DESCRIPTION
returns the title field from a url.

works but if you run the tests you'll see it is still returning a promise (which contains the title). how does that get handled?

the problem last night was using <\title> instead of </title>
and using global.